### PR TITLE
use `_` instead of `()` since compiler complains

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
         "react-dom": "^16.8.1",
         "reason-react": ">=0.7.0"
     },
+    "peerDependencies": {
+      "bs-platform": "^5 || ^7"
+    },
     "devDependencies": {
-        "bs-platform": "^5.0.6"
+        "bs-platform": "^7"
     }
 }

--- a/src/hooks/useHover.re
+++ b/src/hooks/useHover.re
@@ -4,8 +4,8 @@ let useHover = () => {
   let (isHovered, setIsHovered) = React.useState(() => false);
   let ref = React.useRef(Js.Nullable.null);
 
-  let onMouseOver = () => setIsHovered(_ => true);
-  let onMouseOut = () => setIsHovered(_ => false);
+  let onMouseOver = _ => setIsHovered(_ => true);
+  let onMouseOut = _ => setIsHovered(_ => false);
 
   React.useEffect1(
     () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@ bs-intersection-observer@^0.1.2:
   resolved "https://registry.yarnpkg.com/bs-intersection-observer/-/bs-intersection-observer-0.1.2.tgz#1e2eef58c16f3c65dedd5973142eb3f61d2fc129"
   integrity sha512-Ni30XY9Agly91ZohLDs0Y5I/M17orGUusOEUiEtGnDj623l3g2HmWxSSJ22mVPZAmtTWIzEUkPrw49RVZd7MZg==
 
-bs-platform@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
+bs-platform@^7:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.3.2.tgz#301f5c9b4e8cf5713cb60ca22e145e56e793affe"
+  integrity sha512-seJL5g4anK9la4erv+B2o2sMHQCxDF6OCRl9en3hbaUos/S3JsusQ0sPp4ORsbx5eXfHLYBwPljwKXlgpXtsgQ==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Maybe this is a bs-platform v7 thing, but my compiler was complaining about `()` used as a pattern in a function passed to `addEventListener`. 